### PR TITLE
Fix tests due to changes in rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # To test on latest Rails release, use the following:
 gem 'rails'
 gem 'minitest'
+gem 'rails-dom-testing'
 
 # To test on Rails 4.0.x release, use the following e.g. for 4.0.1:
 # gem 'rails', '= 4.0.1'


### PR DESCRIPTION
- Several tests were failing for various reasons
- DomAssertions were removed
  (http://apidock.com/rails/ActionDispatch/Assertions/DomAssertions/assert_dom_equal)
  use https://github.com/rails/rails-dom-testing
- Rails 4.2 changed the sanitize method
  http://blog.plataformatec.com.br/2014/07/the-new-html-sanitizer-in-rails-4-2/
- mail_to encodes +
  [3] pry(main)> helper.mail_to("+bbecker@t1dexchange.org")
  => "<a href=\"mailto:%2Bbbecker@t1dexchange.org\">+bbecker@t1dexchange.org</a>"
